### PR TITLE
Refactor : 대시보드 조회 로직 최적화 - QuitSurvey 엔터티 전체 조회(findAll) 로직 제거, 필요한 필드만 조회하기 위한 LightDTO 도입

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="EntryPointsManager">
+    <list size="1">
+      <item index="0" class="java.lang.String" itemvalue="lombok.Getter" />
+    </list>
+  </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$/backend" />

--- a/backend/src/main/java/org/example/nosmoke/dto/quitsurvey/QuitSurveyLightDto.java
+++ b/backend/src/main/java/org/example/nosmoke/dto/quitsurvey/QuitSurveyLightDto.java
@@ -1,0 +1,15 @@
+package org.example.nosmoke.dto.quitsurvey;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class QuitSurveyLightDto {
+
+    private final boolean isSuccess;
+    private final LocalDateTime createdAt;
+
+}

--- a/backend/src/main/java/org/example/nosmoke/repository/QuitSurveyRepository.java
+++ b/backend/src/main/java/org/example/nosmoke/repository/QuitSurveyRepository.java
@@ -1,7 +1,10 @@
 package org.example.nosmoke.repository;
 
+import org.example.nosmoke.dto.quitsurvey.QuitSurveyLightDto;
 import org.example.nosmoke.entity.QuitSurvey;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,4 +13,10 @@ public interface QuitSurveyRepository extends JpaRepository<QuitSurvey, Long> {
     List<QuitSurvey> findByUserId(Long userId);
 
     List<QuitSurvey> findTop5ByUserIdOrderByCreatedAtDesc(Long userId);
+
+    @Query("SELECT new org.example.nosmoke.dto.quitsurvey.QuitSurveyLightDto(q.isSuccess, q.createdAt) " +
+            "FROM QuitSurvey q " +
+            "WHERE q.userId = :userId " +
+            "ORDER BY q.createdAt ASC")
+    List<QuitSurveyLightDto> findAllLightByUserId(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/org/example/nosmoke/service/dashboard/DashboardService.java
+++ b/backend/src/main/java/org/example/nosmoke/service/dashboard/DashboardService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.example.nosmoke.dto.dashboard.DashboardResponseDto;
+import org.example.nosmoke.dto.quitsurvey.QuitSurveyLightDto;
 import org.example.nosmoke.entity.QuitSurvey;
 import org.example.nosmoke.entity.SmokingInfo;
 import org.example.nosmoke.entity.User;
@@ -40,7 +41,10 @@ public class DashboardService {
         SmokingInfo smokingInfo = smokingInfoRepository.findByUserId(userId)
                 .orElse(null); // 흡연 정보 기 미등록 시 null 허용해야
 
-        List<QuitSurvey> surveys = quitSurveyRepository.findByUserId(userId);
+        // DTO 조회로 변경
+        // DB에서 10만개 데이터를 가져와도, 텍스트 필드가 빠져 메모리 사용량 줄어듦
+        // 또한 DB에서 정렬되어 오기에 CPU save 가능
+        List<QuitSurveyLightDto> surveys = quitSurveyRepository.findAllLightByUserId(userId);
 
         // 기본 정보 계산
         long quitDays = 0;
@@ -66,10 +70,10 @@ public class DashboardService {
         int currentStreak = 0;
         int longestStreak = 0;
 
-        // survey를 날짜순 정렬, 가져와서 isSuccess가 얼마나 유지되는지 확인해보자
-        surveys.sort((s1, s2) -> s1.getCreatedAt().compareTo(s2.getCreatedAt()));
+        // 이미 정렬되어 받아오기에 주석 처리
+//        surveys.sort((s1, s2) -> s1.getCreatedAt().compareTo(s2.getCreatedAt()));
 
-        for (QuitSurvey survey : surveys) {
+        for (QuitSurveyLightDto survey : surveys) {
             if(survey.isSuccess()){
                 currentStreak++;
             } else {


### PR DESCRIPTION
## 📌 작업 내용
- 대시보드 조회 성능 최적화 (OOM 방지)
   - 기존 QuitSurvey 엔티티 전체 조회(findAll) 방식을 필요한 필드만 조회하는 QuitSurveyLightDto Projection 방식으로 변경하여 힙 메모리 사용량을 대폭 줄임.

- 정렬 로직 개선
   - 애플리케이션 메모리에서 수행하던 정렬(List.sort)을 제거하고, DB 레벨에서 정렬된 데이터를 가져오도록(ORDER BY created_at ASC) 쿼리를 튜닝함.

- 성능 개선 결과
  - K6 부하 테스트 결과, 대량의 데이터(10만 건) 조회 시 응답 속도가 약 15s → 1.71s로 7배 이상 단축.
  - 더불어 OOM 위험을 나타내는 그래프 수치도 줄어드는 것을 확인할 수 있었음.


## 🔗 관련 이슈 (선택)
- Closes #15 

## 📝 변경 유형
- [ ] 🐛 버그 수정 (Bug fix)
- [ ] ✨ 기능 추가 (New feature)
- [x] ♻️ 코드 리팩토링 (Refactoring)
- [ ] 📚 문서 업데이트 (Documentation)
- [ ] 🎨 스타일/UI 수정 (Style/UI)
- [x] 🔧 기타 (Performance)

## ✅ 체크리스트
- [x] 코드가 정상적으로 빌드/실행 되나요?
- [ ] 테스트 코드를 작성/실행 했나요?
- [x] 불필요한 주석이나 디버깅 코드는 삭제했나요?

## 📸 스크린샷 (선택)
<img width="1640" height="1518" alt="image" src="https://github.com/user-attachments/assets/ee0a7c70-6a59-4d74-8e08-4feb0f010db6" />

<img width="1464" height="588" alt="image" src="https://github.com/user-attachments/assets/b1f22c80-3f06-4628-b461-5882b39f0524" />


