### PR TITLE
refactor : quitsurvey 호출에 LIMIT 단위의 Page 적용하여 조회속도 개선

### DIFF
--- a/backend/src/main/java/org/example/nosmoke/entity/QuitSurvey.java
+++ b/backend/src/main/java/org/example/nosmoke/entity/QuitSurvey.java
@@ -7,7 +7,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @Entity
-@Table(name="quit_survey")
 public class QuitSurvey extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/org/example/nosmoke/repository/QuitSurveyRepository.java
+++ b/backend/src/main/java/org/example/nosmoke/repository/QuitSurveyRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import org.springframework.data.domain.Pageable;
 import java.util.List;
 @Repository
 public interface QuitSurveyRepository extends JpaRepository<QuitSurvey, Long> {
@@ -14,9 +15,10 @@ public interface QuitSurveyRepository extends JpaRepository<QuitSurvey, Long> {
 
     List<QuitSurvey> findTop5ByUserIdOrderByCreatedAtDesc(Long userId);
 
+    // pageable 추가 : 원하는 LIMIT 만큼 잘라보기
     @Query("SELECT new org.example.nosmoke.dto.quitsurvey.QuitSurveyLightDto(q.isSuccess, q.createdAt) " +
             "FROM QuitSurvey q " +
             "WHERE q.userId = :userId " +
-            "ORDER BY q.createdAt ASC")
-    List<QuitSurveyLightDto> findAllLightByUserId(@Param("userId") Long userId);
+            "ORDER BY q.createdAt DESC") // 최신 순으로, 금연 몇일 했는지
+    List<QuitSurveyLightDto> findAllLightByUserId(@Param("userId") Long userId, Pageable pageable);
 }


### PR DESCRIPTION
## 📌 작업 내용
- 대시보드 조회 성능 이슈 해결 (Network I/O 및 메모리 최적화)
   - 기존: 전체 기간의 금연 기록(QuitSurvey)을 모두 조회하여 데이터 양이 많아질수록 응답 속도가 급격히 저하됨 (10만 건 기준 약 15s 소요).
   - 개선: 1년(365일) 이상 금연 성공 시 사실상 금연 성공 이라는 비즈니스 기준을 적용. DB 조회 시 최근 365건으로 데이터 페이징(LIMIT)을 적용함.

- 스트릭(Streak) 계산 로직 최적화
   - 전체 데이터를 순회하며 계산하던 방식에서, 최신 데이터부터 역순으로 조회하여 실패 기록을 만나는 즉시 계산을 종료(break)하도록 로직을 변경했습니다.

## 🔗 관련 이슈 (선택)
- (관련된 이슈 번호가 있다면 링크를 걸어주세요. 예: #12)
- Closes #15 

## 📝 변경 유형
- [ ] 🐛 버그 수정 (Bug fix)
- [ ] ✨ 기능 추가 (New feature)
- [x] ♻️ 코드 리팩토링 (Refactoring)
- [ ] 📚 문서 업데이트 (Documentation)
- [ ] 🎨 스타일/UI 수정 (Style/UI)
- [x] 🔧 기타 (Performance)

## ✅ 체크리스트
- [x] 코드가 정상적으로 빌드/실행 되나요?
- [ ] 테스트 코드를 작성/실행 했나요?
- [x] 불필요한 주석이나 디버깅 코드는 삭제했나요?

## 📸 스크린샷 (선택)
(UI 변경 사항이 있다면 스크린샷이나 GIF를 첨부해주세요)
[응답속도가 97.83ms 으로 크게 개선 되었으며]
<img width="1612" height="1484" alt="image" src="https://github.com/user-attachments/assets/e3fed307-8bcc-4a98-874c-3f505efbfea7" />
[OOM 우려도 잦아들었습니다]
<img width="1454" height="580" alt="image" src="https://github.com/user-attachments/assets/059abe29-d049-49cc-b65b-9773b0c8a496" />
